### PR TITLE
Move and resize README logo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # PHPSci CArray Extension
 
-![](https://i.imgur.com/QoIbhqj.png)
+<img src="https://i.imgur.com/QoIbhqj.png" alt="PHPSci CArray Logo" width="400"/>
 
 PHPSci CArray is a high-performance scientific computing library for PHP developed in C and based on the original NumPy code. CArrays offer a solid alternative to PHP arrays as well as compatibility with codes developed using NumPy.
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
-# PHPSci CArray Extension
-
 <img src="https://i.imgur.com/QoIbhqj.png" alt="PHPSci CArray Logo" width="400"/>
+
+# PHPSci CArray Extension
 
 PHPSci CArray is a high-performance scientific computing library for PHP developed in C and based on the original NumPy code. CArrays offer a solid alternative to PHP arrays as well as compatibility with codes developed using NumPy.
 


### PR DESCRIPTION
Currently, the Logo on README has no size limit, and is placed between the title and description.
<details>
  <summary>Current screenshot</summary>

  ![Before](https://user-images.githubusercontent.com/7695608/104110782-b1c77b80-52b9-11eb-8048-4b63d03a767e.png)

</details>

This PR limits the logo 400px width and moves it to above the title:

![After](https://user-images.githubusercontent.com/7695608/104110822-31554a80-52ba-11eb-9040-d611185f31fe.png)